### PR TITLE
Don't attempt to extract secure env variables on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ cache:
   directories:
     - node_modules
 before_deploy:
-  - openssl aes-256-cbc -K $encrypted_b0dab8baefe0_key -iv $encrypted_b0dab8baefe0_iv
-  -in client-secret.json.enc -out client-secret.json -d
+  - openssl aes-256-cbc -K $encrypted_b0dab8baefe0_key -iv $encrypted_b0dab8baefe0_iv -in client-secret.json.enc -out client-secret.json -d
   - node gen.js
 deploy:
   provider: gae

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ node_js:
 cache:
   directories:
     - node_modules
-before_install:
-- openssl aes-256-cbc -K $encrypted_b0dab8baefe0_key -iv $encrypted_b0dab8baefe0_iv
-  -in client-secret.json.enc -out client-secret.json -d
 before_deploy:
+  - openssl aes-256-cbc -K $encrypted_b0dab8baefe0_key -iv $encrypted_b0dab8baefe0_iv
+  -in client-secret.json.enc -out client-secret.json -d
   - node gen.js
 deploy:
   provider: gae


### PR DESCRIPTION
Only PRs which match this destination (webcomponents/community) have secure environment variables. Since these are only needed for deployment, skip this step on PR builds.