### PR TITLE
Fix quotes in introduction example

### DIFF
--- a/static/introduction.md
+++ b/static/introduction.md
@@ -63,11 +63,11 @@ Using a custom element is no different to using a `<div>` or any other element. 
 ```html
 <script>
 // Create with javascript
-var newDrawer = document.createElement(‘app-drawer’);
+var newDrawer = document.createElement('app-drawer');
 // Add it to the page
 document.body.appendChild(newDrawer);
 // Attach event listeners
-document.querySelector(‘app-drawer’).addEventListener(‘open’, function() {...});
+document.querySelector('app-drawer').addEventListener('open', function() {...});
 </script>
 ```
 


### PR DESCRIPTION
The example included "pretty" quotes instead of simple single quotes for strings, thus causing an `illegal character` syntax error if copy-pasted.