### PR TITLE
HAX - floss weekly interview added to podcast section

### DIFF
--- a/authors.js
+++ b/authors.js
@@ -113,6 +113,13 @@ module.exports = {
         gravatar: "f3d812c50181277a75a997270518ee15",
         twitter: "findajit"
     },
+    btopro: {
+        name: "Bryan Ollendyke",
+        bio: "Bryan is lead of HAX and ELMS: Learning Network at Penn State. ELMS:LN and HAX seek to democratise content production and transform education through advanced authoring tools.",
+        gravatar: "8f21ddd50ee3f5856d9be912e6a5b37d",
+        github: "329735",
+        twitter: "btopro"
+    },
     bill_heaton: {
         name: "Bill Heaton",
         bio: "Bill is a Senior UI Engineer at CrowdStrike who loves to build great applications with Ember.js.",

--- a/documents/podcasts/hax-floss-weekly.md
+++ b/documents/podcasts/hax-floss-weekly.md
@@ -1,0 +1,11 @@
+---
+title: "HAX - FLOSS Weekly 495"
+authors: [btopro]
+podcast: "FLOSS Weekly"
+date: 2018-11-06
+original_date: 2018-08-29
+link: "https://www.stitcher.com/podcast/twit/floss-weekly/e/56008377"
+category: podcasts
+---
+
+Bryan Ollendyke is the lead of the HAX the web, web component authoring system as well as lead of the ELMS: Learning Network project. He's been a 100% effort FOSS developer for over 10 years at Penn State, meaning every line he's written the last 10 years has been an open contribution!


### PR DESCRIPTION
Adds an interview about HAX which has many tags on here and the podcast veers into discussion of web components / this site. Good entry into making newer articles show up in the community section to emphasis to new people that we...have...a....community :)